### PR TITLE
Setup ReadTheDocs

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -141,7 +141,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install pipx twine openbabel<3.0.0
+        pip install pipx twine openbabel>=3.0.0
 
     - name: Build package
       run: |

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1,13 +1,22 @@
 name: mda_openbabel_converter-docs
 channels:
-
   - conda-forge
-
+  - defaults
 dependencies:
-    # Base depends
+  # Base depends
   - python
   - pip
-
   - mdanalysis-sphinx-theme >=1.0.1
-    # Pip-only installs
-  #- pip:
+
+  # MDAnalysis
+  - MDAnalysis
+  - MDAnalysisTests
+
+  # OpenBabel
+  - openbabel
+
+  # Testing
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - codecov

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   - MDAnalysisTests
 
   # OpenBabel
-  - openbabel
+  - openbabel >= 3.0.0
 
   # Testing
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ maintainers = [
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "MDAnalysis>=2.0.0",
-    "openbabel>=3.0.0"
+    "MDAnalysis>=2.0.0"
 ]
 keywords = [
     "molecular simulations",

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -7,10 +7,10 @@ build:
   tools:
     python: "mambaforge-4.10"
 
+conda:
+  environment: docs/requirements.yaml
+
 python:
   install:
     - method: pip
       path: .
-
-conda:
-  environment: docs/requirements.yaml


### PR DESCRIPTION
Sorting requirements files so ReadTheDocs can build openbabel with conda instead of pip. Working towards getting #3 going.

Currently the build from main fails on ReadTheDocs as it attempts to build the wheel for openbabel.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [X] Issue raised/referenced?
